### PR TITLE
Soft adjust

### DIFF
--- a/src/ESP/profx_driver.cu
+++ b/src/ESP/profx_driver.cu
@@ -240,14 +240,17 @@ __host__ void ESP::ProfX(const SimulationSetup& sim,
         dry_conv_adj<<<NBRT, NTH>>>(pressure_d,    // Pressure [Pa]
                                     pressureh_d,   // mid-point pressure [Pa]
                                     temperature_d, // Temperature [K]
-                                    pt_d,          // Pot temperature [K]
-                                    Rho_d,         // Density [m^3/kg]
-                                    Cp_d,          // Specific heat capacity [J/kg/K]
-                                    Rd_d,          // Gas constant [J/kg/K]
-                                    sim.Gravit,    // Gravity [m/s^2]
-                                    Altitude_d,    // Altitudes of the layers
-                                    Altitudeh_d,   // Altitudes of the interfaces
+                                    profx_Qheat_d,
+                                    pt_d,        // Pot temperature [K]
+                                    Rho_d,       // Density [m^3/kg]
+                                    Cp_d,        // Specific heat capacity [J/kg/K]
+                                    Rd_d,        // Gas constant [J/kg/K]
+                                    sim.Gravit,  // Gravity [m/s^2]
+                                    Altitude_d,  // Altitudes of the layers
+                                    Altitudeh_d, // Altitudes of the interfaces
+                                    timestep,
                                     sim.conv_adj_iter,
+                                    sim.soft_adjustment,
                                     point_num, // Number of columns
                                     nv);       // number of vertical layers
     }

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -373,6 +373,8 @@ int main(int argc, char** argv) {
 
     config_reader.append_config_var("conv_adj", sim.conv_adj, conv_adj_default);
     config_reader.append_config_var("conv_adj_iter", sim.conv_adj_iter, conv_adj_iter_default);
+    config_reader.append_config_var(
+        "soft_adjustment", sim.soft_adjustment, soft_adjustment_default);
 
     int GPU_ID_N = 0;
     config_reader.append_config_var("GPU_ID_N", GPU_ID_N, GPU_ID_N_default);

--- a/src/headers/define.h
+++ b/src/headers/define.h
@@ -117,6 +117,9 @@
 // number of times to execute per time step
 // (repeats entire algorithm if > 1)
 #define conv_adj_iter_default 1
+#define soft_adjustment_default true
+// true = soft adjustment: calculate tendencies due to convection, forward to dyn core
+// false = hard adjustment: force profiles to neutral during profx step
 
 #define init_PT_profile_default "isothermal"
 #define kappa_lw_default 0.002 // m^2 kg^-1

--- a/src/headers/simulation_setup.h
+++ b/src/headers/simulation_setup.h
@@ -102,6 +102,8 @@ public:
 
     bool conv_adj;
     int  conv_adj_iter;
+    bool soft_adjustment;
+
     bool gcm_off;
     bool single_column;
 


### PR DESCRIPTION
Added soft_adjustment option which makes convective adjustment scheme produce pressure tendencies that are forwarded to the dyn core (soft adjustment) rather than forcing profiles immediately to neutral (hard adjustment). The user can choose according to the needs of their situation