### PR TITLE
High order diff fix

### DIFF
--- a/ifile/earth_acoustic_test.thr
+++ b/ifile/earth_acoustic_test.thr
@@ -150,7 +150,7 @@ HyDiff  =  false
 DivDampP =   true
 
 # Strength of diffusion
-Diffc = 0.02
+Diffc = 0.0
 
 # Strength of divergence damping
 DivDampc = 0.02

--- a/ifile/earth_acoustic_test.thr
+++ b/ifile/earth_acoustic_test.thr
@@ -150,7 +150,7 @@ HyDiff  =  false
 DivDampP =   true
 
 # Strength of diffusion
-Diffc = 0.0
+Diffc = 0.02
 
 # Strength of divergence damping
 DivDampc = 0.02

--- a/ifile/input_template.thr
+++ b/ifile/input_template.thr
@@ -230,7 +230,7 @@ Dv_sponge = 0.01
 # bottom of diffusive sponge layer (fractional height)
 ns_diff_sponge = 0.75
 
-# order of diffusion operator in diff sponge (2 or 4)
+# order of diffusion operator in diff sponge (multiple of 2 <= HyDiffOrder)
 order_diff_sponge = 2
 
 #-- Radiative transfer (double gray and two streams ) common options -------------------#

--- a/src/ESP/esp_initial.cu
+++ b/src/ESP/esp_initial.cu
@@ -748,19 +748,19 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
                         pressure_h[i * nv + lev] / (sim.Rd * temperature_h[i * nv + lev]);
                 }
             }
-            { //hack to test diffusion scheme
-                double lat, lon, phi0 = 0, lambda0 = 0, r, v, rhoU;
-                lat  = lonlat_h[i * 2 + 1];
-                lon  = lonlat_h[i * 2];
-                r    = acos(sin(phi0) * sin(lat) + cos(phi0) * cos(lat) * cos(lon - lambda0));
-                v    = 1.0;
-                rhoU = v * r;
-                for (int lev = 0; lev < nv; lev++) {
-                    Mh_h[i * 3 * nv + 3 * lev + 0] = rhoU * (-sin(lon));
-                    Mh_h[i * 3 * nv + 3 * lev + 1] = rhoU * cos(lon);
-                    Mh_h[i * 3 * nv + 3 * lev + 2] = 0.0;
-                }
-            }
+            // { //hack to test diffusion scheme
+            //     double lat, lon, phi0 = 0, lambda0 = 0, r, v, rhoU;
+            //     lat  = lonlat_h[i * 2 + 1];
+            //     lon  = lonlat_h[i * 2];
+            //     r    = acos(sin(phi0) * sin(lat) + cos(phi0) * cos(lat) * cos(lon - lambda0));
+            //     v    = 1.0;
+            //     rhoU = v * r;
+            //     for (int lev = 0; lev < nv; lev++) {
+            //         Mh_h[i * 3 * nv + 3 * lev + 0] = rhoU * (-sin(lon));
+            //         Mh_h[i * 3 * nv + 3 * lev + 1] = rhoU * cos(lon);
+            //         Mh_h[i * 3 * nv + 3 * lev + 2] = 0.0;
+            //     }
+            // }
         }
         if (core_benchmark == JET_STEADY) {
             //  Number of threads per block.
@@ -989,9 +989,6 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
             }
         }
     }
-    printf("Khyp4 = %g\n", Kdh4_h[nv - 1]);
-    printf("Khyp2 = %g\n", Kdh2_h[nv - 1]);
-
 
     //  Diffusion
     //  Vertical

--- a/src/ESP/esp_initial.cu
+++ b/src/ESP/esp_initial.cu
@@ -371,6 +371,7 @@ ESP::alloc_data(bool globdiag, bool output_mean, bool out_interm_momentum, bool 
     cudaMalloc((void **)&diffw_d, nv * point_num * sizeof(double));
     cudaMalloc((void **)&diffrh_d, nv * point_num * sizeof(double));
     cudaMalloc((void **)&diff_d, 6 * nv * point_num * sizeof(double));
+    cudaMalloc((void **)&diff_sponge_d, 6 * nv * point_num * sizeof(double));
     cudaMalloc((void **)&divg_Mh_d, 3 * nv * point_num * sizeof(double));
 
     cudaMalloc((void **)&Kdh2_d, nv * sizeof(double));
@@ -742,6 +743,19 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
                         pressure_h[i * nv + lev] / (sim.Rd * temperature_h[i * nv + lev]);
                 }
             }
+            { //hack to test diffusion scheme
+                double lat, lon, phi0 = 0, lambda0 = 0, r, v, rhoU;
+                lat  = lonlat_h[i * 2 + 1];
+                lon  = lonlat_h[i * 2];
+                r    = acos(sin(phi0) * sin(lat) + cos(phi0) * cos(lat) * cos(lon - lambda0));
+                v    = 0.0;
+                rhoU = v * r;
+                for (int lev = 0; lev < nv; lev++) {
+                    Mh_h[i * 3 * nv + 3 * lev + 0] = rhoU * (-sin(lon));
+                    Mh_h[i * 3 * nv + 3 * lev + 1] = rhoU * cos(lon);
+                    Mh_h[i * 3 * nv + 3 * lev + 2] = 0.0;
+                }
+            }
         }
         if (core_benchmark == JET_STEADY) {
             //  Number of threads per block.
@@ -782,6 +796,7 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
                 pressure_h, pressure_d, point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
             cudaMemcpy(Rho_h, Rho_d, point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
         }
+
 
         simulation_start_time = 0.0;
     } //end if rest
@@ -961,14 +976,18 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
             else {
                 ksponge = 0;
             }
-            if (order_diff_sponge == 2) {
-                Kdh2_h[lev] = ksponge * pow(dbar, 2.) / timestep_dyn;
-            }
-            else if (order_diff_sponge == 4) {
-                Kdh4_h[lev] += ksponge * pow(dbar, 4.) / timestep_dyn;
-            }
+            Kdh2_h[lev] = ksponge * pow(dbar, 1.0 * order_diff_sponge) / timestep_dyn;
+            // if (order_diff_sponge == 2) {
+            //     Kdh2_h[lev] = ksponge * pow(dbar, 2.) / timestep_dyn;
+            // }
+            // else if (order_diff_sponge == 4) {
+            //     Kdh4_h[lev] += ksponge * pow(dbar, 4.) / timestep_dyn;
+            // }
         }
     }
+    printf("Khyp4 = %g\n", Kdh4_h[nv - 1]);
+    printf("Khyp2 = %g\n", Kdh2_h[nv - 1]);
+
 
     //  Diffusion
     //  Vertical
@@ -1077,6 +1096,8 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
     cudaMemset(diffw_d, 0, sizeof(double) * nv * point_num);
     cudaMemset(diffrh_d, 0, sizeof(double) * nv * point_num);
     cudaMemset(diff_d, 0, sizeof(double) * 6 * nv * point_num);
+    if (sim.DiffSponge)
+        cudaMemset(diff_sponge_d, 0, sizeof(double) * 6 * nv * point_num);
     cudaMemset(divg_Mh_d, 0, sizeof(double) * 3 * nv * point_num);
 
     cudaMemset(diffprv_d, 0, sizeof(double) * nv * point_num);

--- a/src/ESP/esp_initial.cu
+++ b/src/ESP/esp_initial.cu
@@ -533,29 +533,6 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
 
                         it++;
                     }
-                    if (i == 0) {
-                        double hs, dpdz, rhog;
-                        if (lev == 0) {
-                            dpdz = (pressure_h[i * nv + lev] - sim.P_Ref) / dz;
-                            rhog = sim.Gravit * (Rho_h[i * nv + lev] * r_int + rho_L * l_int);
-                        }
-                        else {
-                            dpdz = (pressure_h[i * nv + lev] - pressure_h[i * nv + lev - 1]) / dz;
-                            rhog =
-                                sim.Gravit
-                                * (Rho_h[i * nv + lev] * r_int + Rho_h[i * nv + lev - 1] * l_int);
-                        }
-                        hs = dpdz + rhog;
-                        // printf("%d, %f, %f, %#.15g, %#.15g,%#.15g,%#.15g, %#.15g\n",
-                        //        lev,
-                        //        Altitude_h[lev],
-                        //        dz,
-                        //        pressure_h[i * nv + lev],
-                        //        Rho_h[i * nv + lev],
-                        //        dpdz,
-                        //        rhog,
-                        //        hs);
-                    }
                 }
             }
             else {

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -88,8 +88,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
     dim3 NBALL1((point_num / NTH) + 1, nv, 1); //Number of blocks to execute on all grid points
 
     //  Number of Small steps
-    double ns_totald = 1; // Maximum number of small steps in a large step (double ).
-    int    ns_totali = 1; // Maximum number of small steps in a large step (integer).
+    double ns_totald = 6; // Maximum number of small steps in a large step (double ).
+    int    ns_totali = 6; // Maximum number of small steps in a large step (integer).
     int    ns_it;         // Number of small steps in each large step.
     double times;         // Sub-timestep.
 
@@ -127,7 +127,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                    "W_d" /*, "tracer_d", "tracers_d", "tracerk_d"*/));
 
     //  Loop for large time integration.
-    for (int rk = 0; rk < 1; rk++) {
+    for (int rk = 0; rk < 3; rk++) {
         //      Local variables to define the length (times) and the number of the small steps (ns_it).
         if (rk == 0)
             ns_it = 1;
@@ -279,13 +279,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
             cudaMemset(diff_d, 0, sizeof(double) * 6 * point_num * nv);
 
             cudaDeviceSynchronize();
-            // bool firststep;
             int stepnum = 0;
             for (int ihyp = 0; ihyp < sim.HyDiffOrder / 2 - 1; ihyp++) {
-                // if (ihyp == 0)
-                //     firststep = 1;
-                // else
-                //     firststep = 0;
                 //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
                 Diffusion_Op<LN, LN><<<NBD, NT>>>(diffmh_d,
                                                   diffw_d,

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -279,18 +279,19 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
             cudaMemset(diff_d, 0, sizeof(double) * 6 * point_num * nv);
 
             cudaDeviceSynchronize();
-            bool firststep;
+            // bool firststep;
             for (int ihyp = 0; ihyp < sim.HyDiffOrder / 2 - 1; ihyp++) {
-                if (ihyp == 0)
-                    firststep = 1;
-                else
-                    firststep = 0;
+                // if (ihyp == 0)
+                //     firststep = 1;
+                // else
+                //     firststep = 0;
                 //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
                 Diffusion_Op<LN, LN><<<NBD, NT>>>(diffmh_d,
                                                   diffw_d,
                                                   diffrh_d,
                                                   diffpr_d,
                                                   diff_d,
+                                                  diff_sponge_d,
                                                   Mhk_d,
                                                   Rhok_d,
                                                   temperature_d,
@@ -308,7 +309,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                   Cp_d,
                                                   maps_d,
                                                   nl_region,
-                                                  firststep,
+                                                  ihyp,
                                                   0,
                                                   sim.DeepModel,
                                                   sim.DiffSponge,
@@ -324,6 +325,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                    diffrh_d,
                                                    diffpr_d,
                                                    diff_d,
+                                                   diff_sponge_d,
                                                    Mhk_d,
                                                    Rhok_d,
                                                    temperature_d,
@@ -342,7 +344,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                    Cp_d,
                                                    point_local_d,
                                                    point_num,
-                                                   firststep,
+                                                   ihyp,
                                                    0,
                                                    sim.DeepModel,
                                                    sim.DiffSponge,
@@ -366,6 +368,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                               diffrh_d,
                                               diffpr_d,
                                               diff_d,
+                                              diff_sponge_d,
                                               Mhk_d,
                                               Rhok_d,
                                               temperature_d,
@@ -398,6 +401,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                diffrh_d,
                                                diffpr_d,
                                                diff_d,
+                                               diff_sponge_d,
                                                Mhk_d,
                                                Rhok_d,
                                                temperature_d,

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -88,8 +88,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
     dim3 NBALL1((point_num / NTH) + 1, nv, 1); //Number of blocks to execute on all grid points
 
     //  Number of Small steps
-    double ns_totald = 6; // Maximum number of small steps in a large step (double ).
-    int    ns_totali = 6; // Maximum number of small steps in a large step (integer).
+    double ns_totald = 1; // Maximum number of small steps in a large step (double ).
+    int    ns_totali = 1; // Maximum number of small steps in a large step (integer).
     int    ns_it;         // Number of small steps in each large step.
     double times;         // Sub-timestep.
 
@@ -127,7 +127,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                    "W_d" /*, "tracer_d", "tracers_d", "tracerk_d"*/));
 
     //  Loop for large time integration.
-    for (int rk = 0; rk < 3; rk++) {
+    for (int rk = 0; rk < 1; rk++) {
         //      Local variables to define the length (times) and the number of the small steps (ns_it).
         if (rk == 0)
             ns_it = 1;
@@ -280,6 +280,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
 
             cudaDeviceSynchronize();
             // bool firststep;
+            int stepnum = 0;
             for (int ihyp = 0; ihyp < sim.HyDiffOrder / 2 - 1; ihyp++) {
                 // if (ihyp == 0)
                 //     firststep = 1;
@@ -309,8 +310,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                   Cp_d,
                                                   maps_d,
                                                   nl_region,
-                                                  ihyp,
-                                                  0,
+                                                  stepnum,
+                                                  false,
                                                   sim.DeepModel,
                                                   sim.DiffSponge,
                                                   order_diff_sponge,
@@ -344,8 +345,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                    Cp_d,
                                                    point_local_d,
                                                    point_num,
-                                                   ihyp,
-                                                   0,
+                                                   stepnum,
+                                                   false,
                                                    sim.DeepModel,
                                                    sim.DiffSponge,
                                                    order_diff_sponge,
@@ -354,6 +355,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                    energy_equation,
                                                    sim.HyDiffOrder);
                 cudaDeviceSynchronize();
+                stepnum += 1;
             }
 
             BENCH_POINT_I_S(current_step, rk, "Diffusion_Op1", (), ("diff_d"))
@@ -386,8 +388,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                               Cp_d,
                                               maps_d,
                                               nl_region,
-                                              0,
-                                              1,
+                                              stepnum,
+                                              true,
                                               sim.DeepModel,
                                               sim.DiffSponge,
                                               order_diff_sponge,
@@ -420,8 +422,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                Cp_d,
                                                point_local_d,
                                                point_num,
-                                               0,
-                                               1,
+                                               stepnum,
+                                               true,
                                                sim.DeepModel,
                                                sim.DiffSponge,
                                                order_diff_sponge,

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -732,11 +732,9 @@ int main(int argc, char** argv) {
     }
 
     if (sim.DiffSponge) {
-        if (order_diff_sponge == 2 || order_diff_sponge == 4) {
-            config_OK &= true;
-        }
-        else {
-            log::printf("order_diff_sponge config option can only be 2 or 4\n");
+        if (order_diff_sponge > sim.HyDiffOrder || order_diff_sponge % 2) {
+            log::printf(
+                "order_diff_sponge config option must be <= HyDiffOrder and a multiple of 2\n");
             config_OK &= false;
         }
     }
@@ -981,7 +979,7 @@ int main(int argc, char** argv) {
     // Register clean up function for exit
     // takes care of freeing cuda memory in case we catch an error and bail out with exit(EXIT_FAILURE)
     atexit(exit_handler);
-    
+
     int max_count = 0;
     //
     //  Make the icosahedral grid

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -1048,6 +1048,7 @@ int main(int argc, char** argv) {
           sim.output_mean,
           sim.out_interm_momentum,
           sim.output_diffusion,
+          sim.DiffSponge,
           init_PT_profile,
           Tint,
           kappa_lw,

--- a/src/headers/debug.h
+++ b/src/headers/debug.h
@@ -46,7 +46,7 @@
 
 // benchmarking
 // if defined run benchmark functions?
-#define BENCHMARKING
+// #define BENCHMARKING
 
 // ***************************************
 // * binary comparison
@@ -63,7 +63,7 @@
 // #define BENCH_COMPARE_EPSILON_VALUE 1e-14
 // ***************************************
 // * check for NaNs
-#define BENCH_NAN_CHECK
+// #define BENCH_NAN_CHECK
 // * below adds checks on device functions (useful for device memory bugs)
 // #define BENCH_CHECK_LAST_CUDA_ERROR
 

--- a/src/headers/debug.h
+++ b/src/headers/debug.h
@@ -46,7 +46,7 @@
 
 // benchmarking
 // if defined run benchmark functions?
-// #define BENCHMARKING
+#define BENCHMARKING
 
 // ***************************************
 // * binary comparison
@@ -63,7 +63,7 @@
 // #define BENCH_COMPARE_EPSILON_VALUE 1e-14
 // ***************************************
 // * check for NaNs
-// #define BENCH_NAN_CHECK
+#define BENCH_NAN_CHECK
 // * below adds checks on device functions (useful for device memory bugs)
 // #define BENCH_CHECK_LAST_CUDA_ERROR
 

--- a/src/headers/dyn/thor_diff.h
+++ b/src/headers/dyn/thor_diff.h
@@ -475,14 +475,14 @@ __global__ void Diffusion_Op(double* diffmh_d,
         }
     }
 
-    if (id == 0 && var < 4 && stepnum < 3) {
-        printf("%d %g\n", stepnum, lap);
-    }
+    // if (id == 0 && var < 4 && stepnum < 3) {
+    //     printf("%d %g\n", stepnum, lap);
+    // }
 
     if (laststep) {
-        if (id == 0 && var == 1) {
-            printf("%d %g %g\n", stepnum, lap, sdiff);
-        }
+        // if (id == 0 && var == 1) {
+        //     printf("%d %g %g\n", stepnum, lap, sdiff);
+        // }
         if (var == 0) {
             diffrh_d[id * nv + lev] = lap;
         }
@@ -515,9 +515,9 @@ __global__ void Diffusion_Op(double* diffmh_d,
     }
     else {
         diff_d[id * nv * 6 + lev * 6 + var] = lap;
-        if (id == 0 && var == 1) {
-            printf("%d %g\n", stepnum, lap);
-        }
+        // if (id == 0 && var == 1) {
+        //     printf("%d %g\n", stepnum, lap);
+        // }
     }
 }
 
@@ -887,9 +887,9 @@ __global__ void Correct_Horizontal(double* diffmh_d, double* diffmv_d, double* f
 
     if (id < num) {
         double dmhr, dmvr;
-        if (id == 0) {
-            printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
-        }
+        // if (id == 0) {
+        //     printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
+        // }
 
         dmhr = func_r_d[id * 3 + 0] * diffmh_d[id * nv * 3 + lev * 3 + 0]
                + func_r_d[id * 3 + 1] * diffmh_d[id * nv * 3 + lev * 3 + 1]
@@ -900,9 +900,9 @@ __global__ void Correct_Horizontal(double* diffmh_d, double* diffmv_d, double* f
         diffmh_d[id * nv * 3 + lev * 3 + 2] += -func_r_d[id * 3 + 2] * dmhr;
 
 
-        if (id == 0) {
-            printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
-        }
+        // if (id == 0) {
+        //     printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
+        // }
 
         dmvr = func_r_d[id * 3 + 0] * diffmv_d[id * nv * 3 + lev * 3 + 0]
                + func_r_d[id * 3 + 1] * diffmv_d[id * nv * 3 + lev * 3 + 1]

--- a/src/headers/dyn/thor_diff.h
+++ b/src/headers/dyn/thor_diff.h
@@ -75,7 +75,7 @@ __global__ void Diffusion_Op(double* diffmh_d,
                              double* Cp_d,
                              int*    maps_d,
                              int     nl_region,
-                             bool    stepnum,
+                             int     stepnum,
                              bool    laststep,
                              bool    DeepModel,
                              bool    DiffSponge,
@@ -103,7 +103,7 @@ __global__ void Diffusion_Op(double* diffmh_d,
     double AT1, AT2;
     // double o3 = 1.0 / 3.0;
     // double o6 = 1.0 / 6.0;
-    double lap, lap1, lap2, lap3, lap4, lap5, lap6;
+    double lap = 0, lap1, lap2, lap3, lap4, lap5, lap6;
     double lapx1, lapx2, lapy1, lapy2, lapz1, lapz2;
     // double dmhz, dmhr;
 
@@ -345,18 +345,18 @@ __global__ void Diffusion_Op(double* diffmh_d,
             pt3 = (y + 2) * nhl + x + 2;
         }
 
-        if (laststep) {
-            // if (var == 0) {
-            vdiff = 0.5 * rscale * sdiff;
-            // }
-            // else {
-            //     vdiff = 0.5 * rscale
-            //             * (2.0 * Rho_s[ir] + Rho_s[pt1] + 2.0 * Rho_s[pt2] + Rho_s[pt3]) * o6
-            //             * sdiff;
-            // }
-        }
-        else
-            vdiff = 0.5 * rscale;
+        // if (laststep) {
+        //     // if (var == 0) {
+        //     vdiff = 0.5 * rscale * sdiff;
+        //     // }
+        //     // else {
+        //     //     vdiff = 0.5 * rscale
+        //     //             * (2.0 * Rho_s[ir] + Rho_s[pt1] + 2.0 * Rho_s[pt2] + Rho_s[pt3]) * o6
+        //     //             * sdiff;
+        //     // }
+        // }
+        // else
+        vdiff = 0.5 * rscale;
 
         if (j == 0) {
             // lapi are the values 'a_s' the gradient will operate on and INCLUDE the
@@ -440,57 +440,73 @@ __global__ void Diffusion_Op(double* diffmh_d,
                 + (lapy1 + lapy2) * nvecoa_d[id * 6 * 3 + j * 3 + 1]
                 + (lapz1 + lapz2) * nvecoa_d[id * 6 * 3 + j * 3 + 2])
                * vdiff;
-
+        // if (id == 0 && var == 1 && j == 4) {
+        //     printf("%d %d  %g\n", stepnum, j, lap);
+        // }
         if (pent_ind && j == 4)
             break;
     }
 
-    if (DiffSponge) {
-        if (stepnum == order_diff_sponge / 2 - 1) {
+    if (laststep)
+        lap *= sdiff;
+
+    if (DiffSponge && order_diff_sponge != HyDiffOrder) {
+        if (stepnum == order_diff_sponge / 2) {
             if (var == 1) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 2) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 3) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 4) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
         }
     }
 
+    if (id == 0 && var < 4 && stepnum < 3) {
+        printf("%d %g\n", stepnum, lap);
+    }
+
     if (laststep) {
+        if (id == 0 && var == 1) {
+            printf("%d %g %g\n", stepnum, lap, sdiff);
+        }
         if (var == 0) {
             diffrh_d[id * nv + lev] = lap;
         }
         if (var == 1) {
             diffmh_d[id * nv * 3 + lev * 3 + 0] = lap;
-            if (DiffSponge) {
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 0] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 2) {
             diffmh_d[id * nv * 3 + lev * 3 + 1] = lap;
-            if (DiffSponge) {
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 1] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 3) {
             diffmh_d[id * nv * 3 + lev * 3 + 2] = lap;
-            if (DiffSponge) {
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 2] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 4) {
             diffw_d[id * nv + lev] = lap;
-            if (DiffSponge) {
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffw_d[id * nv + lev] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
@@ -499,6 +515,9 @@ __global__ void Diffusion_Op(double* diffmh_d,
     }
     else {
         diff_d[id * nv * 6 + lev * 6 + var] = lap;
+        if (id == 0 && var == 1) {
+            printf("%d %g\n", stepnum, lap);
+        }
     }
 }
 
@@ -727,17 +746,17 @@ __global__ void Diffusion_Op_Poles(double* diffmh_d,
         kp1   = (k + 1) % 5;
         kp2   = (k + 2) % 5;
 
-        if (laststep) {
-            // if (var == 0) {
-            vdiff = 0.5 * sdiff * rscale;
-            // }
-            // else {
-            //     vdiff = 0.5 * sdiff * rscale
-            //             * (2.0 * Rho_p[0] + Rho_p[j] + 2.0 * Rho_p[jp1] + Rho_p[jp2]) * o6;
-            // }
-        }
-        else
-            vdiff = 0.5 * rscale;
+        // if (laststep) {
+        //     // if (var == 0) {
+        //     vdiff = 0.5 * sdiff * rscale;
+        //     // }
+        //     // else {
+        //     //     vdiff = 0.5 * sdiff * rscale
+        //     //             * (2.0 * Rho_p[0] + Rho_p[j] + 2.0 * Rho_p[jp1] + Rho_p[jp2]) * o6;
+        //     // }
+        // }
+        // else
+        vdiff = 0.5 * rscale;
 
         if (k == 0) {
             AT1   = rscale / areasTr_p[k];
@@ -800,57 +819,60 @@ __global__ void Diffusion_Op_Poles(double* diffmh_d,
                * vdiff;
     }
 
-    if (DiffSponge) {
-        if (stepnum == order_diff_sponge / 2 - 1) {
+    if (DiffSponge && order_diff_sponge != HyDiffOrder) {
+        if (stepnum == order_diff_sponge / 2) {
             if (var == 1) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 2) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 3) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
             if (var == 4) {
-                diff_sponge_d[id * nv * 6 + lev * 6 + var] =
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_d[id * nv * 6 + lev * 6 + var];
+                diff_sponge_d[id * nv * 6 + lev * 6 + var] = pow(-1.0, order_diff_sponge / 2 + 1)
+                                                             * Rho_d[id * nv + lev] * Kdh2_d[lev]
+                                                             * diff_d[id * nv * 6 + lev * 6 + var];
             }
         }
     }
 
     if (laststep) {
         if (var == 0)
-            diffrh_d[id * nv + lev] = lap;
+            diffrh_d[id * nv + lev] = sdiff * lap;
         if (var == 1) {
-            diffmh_d[id * 3 * nv + lev * 3 + 0] = lap;
-            if (DiffSponge) {
+            diffmh_d[id * 3 * nv + lev * 3 + 0] = sdiff * lap;
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 0] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 2) {
-            diffmh_d[id * 3 * nv + lev * 3 + 1] = lap;
-            if (DiffSponge) {
+            diffmh_d[id * 3 * nv + lev * 3 + 1] = sdiff * lap;
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 1] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 3) {
-            diffmh_d[id * 3 * nv + lev * 3 + 2] = lap;
-            if (DiffSponge) {
+            diffmh_d[id * 3 * nv + lev * 3 + 2] = sdiff * lap;
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
                 diffmh_d[id * nv * 3 + lev * 3 + 2] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 4) {
-            diffw_d[id * nv + lev] = lap;
-            if (DiffSponge) {
-                diffw_d[id * nv + lev] +=
-                    Rho_d[id * nv + lev] * Kdh2_d[lev] * diff_sponge_d[id * nv * 6 + lev * 6 + var];
+            diffw_d[id * nv + lev] = sdiff * lap;
+            if (DiffSponge && order_diff_sponge != HyDiffOrder) {
+                diffw_d[id * nv + lev] += diff_sponge_d[id * nv * 6 + lev * 6 + var];
             }
         }
         if (var == 5)
-            diffpr_d[id * nv + lev] = lap;
+            diffpr_d[id * nv + lev] = sdiff * lap;
     }
     else {
         diff_d[id * nv * 6 + lev * 6 + var] = lap;
@@ -865,6 +887,10 @@ __global__ void Correct_Horizontal(double* diffmh_d, double* diffmv_d, double* f
 
     if (id < num) {
         double dmhr, dmvr;
+        if (id == 0) {
+            printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
+        }
+
         dmhr = func_r_d[id * 3 + 0] * diffmh_d[id * nv * 3 + lev * 3 + 0]
                + func_r_d[id * 3 + 1] * diffmh_d[id * nv * 3 + lev * 3 + 1]
                + func_r_d[id * 3 + 2] * diffmh_d[id * nv * 3 + lev * 3 + 2];
@@ -872,6 +898,11 @@ __global__ void Correct_Horizontal(double* diffmh_d, double* diffmv_d, double* f
         diffmh_d[id * nv * 3 + lev * 3 + 0] += -func_r_d[id * 3 + 0] * dmhr;
         diffmh_d[id * nv * 3 + lev * 3 + 1] += -func_r_d[id * 3 + 1] * dmhr;
         diffmh_d[id * nv * 3 + lev * 3 + 2] += -func_r_d[id * 3 + 2] * dmhr;
+
+
+        if (id == 0) {
+            printf("%g\n", diffmh_d[id * nv * 3 + lev * 3 + 0]);
+        }
 
         dmvr = func_r_d[id * 3 + 0] * diffmv_d[id * nv * 3 + lev * 3 + 0]
                + func_r_d[id * 3 + 1] * diffmv_d[id * nv * 3 + lev * 3 + 1]

--- a/src/headers/dyn/thor_fastmodes.h
+++ b/src/headers/dyn/thor_fastmodes.h
@@ -492,7 +492,7 @@ __global__ void Density_Pressure_Eqs(double *      pressure_d,
 
 
     // Updates density
-    nflxr_s[iri] += dwdz; //hack to test mass conservation
+    nflxr_s[iri] += dwdz;
     Rho_d[id * nv + lev] +=
         (SlowRho_d[id * nv + lev] - nflxr_s[iri]) * dt; //density deviation at time tau+dtau
 

--- a/src/headers/dyn/thor_vertical_int.h
+++ b/src/headers/dyn/thor_vertical_int.h
@@ -102,7 +102,7 @@ __global__ void Vertical_Eq(double *      Whs_d,
     // double Cv = Cp - Rd;
     double C0;
     double xi, xim, xip;
-    double intt, intl, inttm, intlm;
+    double intt, intl, inttm;
     double dSpdz, dPdz;
     double rhohs;
     double aa, bb; // <- thomas alg vars
@@ -191,7 +191,7 @@ __global__ void Vertical_Eq(double *      Whs_d,
                 xim = alth;
                 xip = altht;
 
-                intt = -(xi - xip) * dzp * dzh;
+                // intt = -(xi - xip) * dzp * dzh;
                 intl = (xi - xim) * dzp * dzh;
 
                 xi  = altl;
@@ -199,7 +199,7 @@ __global__ void Vertical_Eq(double *      Whs_d,
                 xip = alth;
 
                 inttm = -(xi - xip) * dzm * dzh;
-                intlm = (xi - xim) * dzm * dzh;
+                // intlm = (xi - xim) * dzm * dzh;
 
                 // get g*Cv/Rd and Cv/Rd/dt^2 at the current interface
                 CRdd = (CRddl * (alt - alth) + CRddu * (alth - altl)) / (alt - altl);
@@ -279,7 +279,7 @@ __global__ void Vertical_Eq(double *      Whs_d,
                 xim = alth;
                 xip = altht;
 
-                intt = -(xi - xip) * dzp * dzh;
+                // intt = -(xi - xip) * dzp * dzh;
                 intl = (xi - xim) * dzp * dzh;
 
                 xi  = altl;
@@ -288,7 +288,7 @@ __global__ void Vertical_Eq(double *      Whs_d,
 
                 // compute coefficients aa, bb, cc of thomas algorithm original matrix
                 inttm = -(xi - xip) * dzm * dzh;
-                intlm = (xi - xim) * dzm * dzh;
+                // intlm = (xi - xim) * dzm * dzh;
 
                 // get g*Cv/Rd and Cv/Rd/dt^2 at the current interface
                 CRdd = (CRddl * (alt - alth) + CRddu * (alth - altl)) / (alt - altl);

--- a/src/headers/esp.h
+++ b/src/headers/esp.h
@@ -409,6 +409,7 @@ public:
         bool                  output_mean,
         bool                  out_interm_momentum,
         bool                  output_diffusion,
+        bool                  DiffSponge,
         init_PT_profile_types init_PT_profile_,
         double                Tint_,
         double                kappa_lw_,
@@ -424,7 +425,7 @@ public:
 
     ~ESP();
 
-    void alloc_data(bool, bool, bool, bool);
+    void alloc_data(bool, bool, bool, bool, bool);
 
     bool initial_values(const std::string &initial_conditions_filename,
                         const std::string &planet_filename,

--- a/src/headers/esp.h
+++ b/src/headers/esp.h
@@ -305,8 +305,9 @@ public:
     double *diffwv_d;
     double *diffrv_d;
 
-    double *diff_d;  //temporary array for diffusion calculation
-    double *diff2_d; //second temp array for diff (vertical)
+    double *diff_d;        //temporary array for diffusion calculation
+    double *diff_sponge_d; //temporary array for diffusive sponge calculation
+    double *diff2_d;       //second temp array for diff (vertical)
     // double *diffv_d1;
     // double *diffv_d2;
     double *divg_Mh_d;


### PR DESCRIPTION
Fix to diffusive sponge layer to work with higher order diffusion. If order_diff_sponge = HyDiffOrder, then this just adds to the horizontal diffusion coefficient and all calculation proceeds normally. Works for order_diff_sponge = 4, 6, 8. If order_diff_sponge < HyDiffOrder, the coefficient is stored separately, and a separate array stores the sponge diffusion until it can be added to the final horizontal diffusion. 

Also fixed minor interpolation error in vertical int.
